### PR TITLE
[python36] Run tests in Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
   - "pypy"
 
 env:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py34, pypy
+envlist = py26, py27, py34, py36, pypy
 
 [testenv]
 setenv =


### PR DESCRIPTION
@bshelton229 or @melinath please review and +1, since Travis tests pass I'm going to assume this library supports Python 3.6